### PR TITLE
Detect if we're running an old version of ftw.tika (< 2.0) against new server

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Detect if we're running an old version of ftw.tika (< 2.0) against the new
+  JAXRS HTTP server and log a helpful error message.
+  [lgraf]
 
 
 1.1.2 (2014-09-01)

--- a/ftw/tika/exceptions.py
+++ b/ftw/tika/exceptions.py
@@ -20,3 +20,9 @@ class TikaJarNotConfigured(Exception):
 class TikaJarNotFound(Exception):
     """Raised if a path to Tika JAR file was specified, but is invalid.
     """
+
+
+class TikaServerProtocolMismatch(Exception):
+    """Raised if the Tika server seems to expect a different protocol than
+    the client.
+    """


### PR DESCRIPTION
Detect if we're running an old version of ftw.tika` (< 2.0) against the [new JAXRS HTTP server](https://github.com/4teamwork/ftw.tika/pull/21) and log a helpful error message.

This PR is against the `1.1.x` branch, which contains the old client implementation that expects a dumb TCP socket server. If for some reason we get a response that looks like HTTP (a `400 Bad Request`, because we sent some random garbage to a server expecting a HTTP request), this is a strong indication that the server is the new JAXRS HTTP server, and we're running an old version of `ftw.tika` against the new server.

We therefore log a message with level `ERROR`, which should end up in Errbit and allow us to upgrade `ftw.tika` accordingly.

@phgross @maethu

/cc @jone
