### PR TITLE
Set timeouts for requests to Tika Server

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Set a default connection timeout of 10s for requests to Tika JAXRS server.
+  [lgraf]
 
 
 2.0 (2014-11-24)


### PR DESCRIPTION
In case the Tika server doesn't respond in a timely manner, `ftw.tika` shouldn't block the Zope thread for too long. One instance where this may happen is if the JVM heap size limit is reached and the JVM runs out of memory.

Therefore we need to set connection and/or read timeouts for the requests to the Tika server (`10s` should probably work fine).
