### PR TITLE
Add support for Tika 1.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,15 +94,15 @@ necessary, copy into your buildout and extend from:
 
     [tika-app-download]
     recipe = hexagonit.recipe.download
-    url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
-    md5sum = 2124a77289efbb30e7228c0f7da63373
+    url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.6/tika-app-1.6.jar
+    md5sum = 2d8af1f228000fcda92bd0dda20b80a8
     download-only = true
     filename = tika-app.jar
 
     [tika-server-download]
     recipe = hexagonit.recipe.download
-    url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
-    md5sum = 0f70548f233ead7c299bf7bc73bfec26
+    url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.6/tika-server-1.6.jar
+    md5sum = cdd68617e511010f76c357700ebad8c7
     download-only = true
     filename = tika-server.jar
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-2.0.2 (unreleased)
+2.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Tika 1.6
+  [lgraf]
 
 
 2.0.1 (2014-12-08)

--- a/ftw/tika/tests/test_converter_server.py
+++ b/ftw/tika/tests/test_converter_server.py
@@ -14,6 +14,9 @@ class TestServerConversion(TestCase):
 
     def test_convert_docx(self):
         converter = TikaConverter()
-        with open(os.path.join(ASSETS, 'lorem.docx')) as file_:
+        filename = 'lorem.docx'
+        with open(os.path.join(ASSETS, filename)) as file_:
             result = converter.convert_server(file_)
-        self.assertEquals('Lorem Ipsum', strip_word_bookmarks(result.strip()))
+        self.assertEquals(
+            'Lorem Ipsum',
+            strip_word_bookmarks(result.strip(), filename=filename))

--- a/ftw/tika/tests/test_utils.py
+++ b/ftw/tika/tests/test_utils.py
@@ -17,6 +17,12 @@ class TestUtils(TestCase):
         with self.assertRaises(ProcessError):
             stdout, stderr = run_process(cmd)
 
-    def test_strip_word_bookmarks(self):
+    def test_strip_word_bookmarks_removes_bookmarks_from_docx(self):
         text = '[bookmark: Foo][bookmark: _GoBack]Lorem Ipsum[bookmark: Foo]'
-        self.assertEquals('Lorem Ipsum', strip_word_bookmarks(text))
+        self.assertEquals(
+            'Lorem Ipsum',
+            strip_word_bookmarks(text, filename='foo.docx'))
+
+    def test_strip_word_bookmarks_doesnt_touch_files_other_than_docx(self):
+        text = '[bookmark: Foo][bookmark: _GoBack]Lorem Ipsum[bookmark: Foo]'
+        self.assertEquals(text, strip_word_bookmarks(text))

--- a/ftw/tika/tests/test_utils.py
+++ b/ftw/tika/tests/test_utils.py
@@ -1,5 +1,6 @@
 from ftw.tika.exceptions import ProcessError
 from ftw.tika.utils import run_process
+from ftw.tika.utils import strip_thumbnail_names
 from ftw.tika.utils import strip_word_bookmarks
 from unittest2 import TestCase
 
@@ -26,3 +27,9 @@ class TestUtils(TestCase):
     def test_strip_word_bookmarks_doesnt_touch_files_other_than_docx(self):
         text = '[bookmark: Foo][bookmark: _GoBack]Lorem Ipsum[bookmark: Foo]'
         self.assertEquals(text, strip_word_bookmarks(text))
+
+    def test_strip_thumbnail_names_removes_thumbnail_filenames(self):
+        text = 'Lorem Ipsum\nthumbnail_0.jpeg'
+        self.assertEquals(
+            'Lorem Ipsum',
+            strip_thumbnail_names(text).strip())

--- a/ftw/tika/utils.py
+++ b/ftw/tika/utils.py
@@ -22,13 +22,25 @@ def run_process(cmd):
         return (stdout, stderr)
 
 
-def strip_word_bookmarks(text):
+def clean_extracted_plaintext(text, filename=''):
+    """Clean up raw plain text returned by either Tika Server or a local tika
+    app by removing common noise that we don't want in the extracted text,
+    like word bookmark names or filenames of thumbnails.
+    """
+    text = strip_word_bookmarks(text, filename)
+    return text
+
+
+def strip_word_bookmarks(text, filename=''):
     """Newer versions of tika also include Word bookmarks in the returned
     plain text. They are inserted in the form
     '[bookmark: Foo][bookmark: _GoBack]Lorem Ipsum'
 
     For our purpose of building the searchable text, we want to strip those.
     """
+    if not filename.lower().endswith('.docx'):
+        return text
+
     pattern = re.compile(r'\[bookmark:.*?\]')
     text = re.sub(pattern, '', text)
     return text

--- a/ftw/tika/utils.py
+++ b/ftw/tika/utils.py
@@ -28,6 +28,7 @@ def clean_extracted_plaintext(text, filename=''):
     like word bookmark names or filenames of thumbnails.
     """
     text = strip_word_bookmarks(text, filename)
+    text = strip_thumbnail_names(text, filename)
     return text
 
 
@@ -42,5 +43,15 @@ def strip_word_bookmarks(text, filename=''):
         return text
 
     pattern = re.compile(r'\[bookmark:.*?\]')
+    text = re.sub(pattern, '', text)
+    return text
+
+
+def strip_thumbnail_names(text, filename=''):
+    """Since Tika 1.6 filenames of thumbnails in office documents also get
+    returned as part of the plain text. Therefore we strip the common
+    default filenames for thumbnails here.
+    """
+    pattern = re.compile(r'thumbnail_[0-9*]\.jpeg')
     text = re.sub(pattern, '', text)
     return text

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '2.0.2.dev0'
+version = '2.1.0.dev0'
 
 tests_require = [
     'Products.CMFCore',

--- a/tika.cfg
+++ b/tika.cfg
@@ -19,15 +19,15 @@ zcml =
 
 [tika-app-download]
 recipe = hexagonit.recipe.download
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
-md5sum = 2124a77289efbb30e7228c0f7da63373
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.6/tika-app-1.6.jar
+md5sum = 2d8af1f228000fcda92bd0dda20b80a8
 download-only = true
 filename = tika-app.jar
 
 [tika-server-download]
 recipe = hexagonit.recipe.download
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
-md5sum = 0f70548f233ead7c299bf7bc73bfec26
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.6/tika-server-1.6.jar
+md5sum = cdd68617e511010f76c357700ebad8c7
 download-only = true
 filename = tika-server.jar
 


### PR DESCRIPTION
Adds support for [Apache Tika 1.6](https://tika.apache.org/1.6/index.html).

With Tika >= 1.6, for many office formats the filenames of thumbnails also get added to the extracted plain text, so those need to be removed. Other than that, this is just a version bump.