### PR TITLE
Add support for Tika 1.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,15 +94,15 @@ necessary, copy into your buildout and extend from:
 
     [tika-app-download]
     recipe = hexagonit.recipe.download
-    url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.6/tika-app-1.6.jar
-    md5sum = 2d8af1f228000fcda92bd0dda20b80a8
+    url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.7/tika-app-1.7.jar
+    md5sum = a3deee3a02d59ad0085123806696f9f8
     download-only = true
     filename = tika-app.jar
 
     [tika-server-download]
     recipe = hexagonit.recipe.download
-    url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.6/tika-server-1.6.jar
-    md5sum = cdd68617e511010f76c357700ebad8c7
+    url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.7/tika-server-1.7.jar
+    md5sum = 97a9bd477747c65c7f89ccac3554f3ed
     download-only = true
     filename = tika-server.jar
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-2.1.1 (unreleased)
+2.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Tika 1.7
+  [lgraf]
 
 
 2.1.0 (2015-10-25)

--- a/ftw/tika/protected_docs.py
+++ b/ftw/tika/protected_docs.py
@@ -1,0 +1,31 @@
+"""Utility functions for detecting password protected documents upon
+conversion failure.
+"""
+
+from ftw.tika import mimetypes
+
+
+PROTECTED_PDF_MSGS = (
+    # Tika 1.5, 1.6
+    'Error: The supplied password does not match either the'
+    ' owner or user password in the document.',
+)
+
+PROTECTED_MSOFFICE_MSGS = (
+    # Tika 1.5, 1.6
+    'org.apache.tika.exception.EncryptedDocumentException',
+)
+
+
+def is_protected_doc(exc, mimetype):
+    """Figure out whether conversion failed because we're dealing with
+    a password protected document, based on the document's MIME type and
+    the Java exception.
+    """
+    if mimetype in mimetypes.PDF_TYPES:
+        return any(msg in str(exc) for msg in PROTECTED_PDF_MSGS)
+
+    if mimetype in mimetypes.MS_OFFICE_TYPES:
+        return any(msg in str(exc) for msg in PROTECTED_MSOFFICE_MSGS)
+
+    return False

--- a/ftw/tika/protected_docs.py
+++ b/ftw/tika/protected_docs.py
@@ -9,10 +9,12 @@ PROTECTED_PDF_MSGS = (
     # Tika 1.5, 1.6
     'Error: The supplied password does not match either the'
     ' owner or user password in the document.',
+    # Tika 1.7
+    'Document is encrypted',
 )
 
 PROTECTED_MSOFFICE_MSGS = (
-    # Tika 1.5, 1.6
+    # Tika 1.5, 1.6, 1.7
     'org.apache.tika.exception.EncryptedDocumentException',
 )
 

--- a/ftw/tika/tests/test_integration.py
+++ b/ftw/tika/tests/test_integration.py
@@ -1,7 +1,12 @@
 from ftw.tika.testing import FTW_TIKA_INTEGRATION_TESTING
 from ftw.tika.testing import TIKA_SERVER_INTEGRATION_TESTING
 from ftw.tika.tests.helpers import convert_asset
+from testfixtures import log_capture
 from unittest2 import TestCase
+
+
+PROTECTED_MSG = (
+    'ftw.tika', 'INFO', 'Could not convert password protected document.')
 
 
 class TestConversion(TestCase):
@@ -42,6 +47,16 @@ class TestConversion(TestCase):
 
     def test_eml_conversion(self):
         self.assertEquals('Lorem Ipsum', convert_asset('lorem.eml'))
+
+    @log_capture('ftw.tika')
+    def test_protected_pdf_conversion(self, log):
+        self.assertEquals('', convert_asset('protected.pdf'))
+        self.assertIn(PROTECTED_MSG, tuple(log.actual()))
+
+    @log_capture('ftw.tika')
+    def test_protected_docx_conversion(self, log):
+        self.assertEquals('', convert_asset('protected.docx'))
+        self.assertIn(PROTECTED_MSG, tuple(log.actual()))
 
 
 class TestServerConversion(TestCase):

--- a/ftw/tika/tests/test_transforms.py
+++ b/ftw/tika/tests/test_transforms.py
@@ -5,10 +5,8 @@ from ZODB.POSException import ConflictError
 from ftw.testing import MockTestCase
 from ftw.tika.exceptions import TikaJarNotConfigured
 from ftw.tika.testing import FTW_TIKA_INTEGRATION_TESTING
-from ftw.tika.tests.helpers import convert_asset
 from ftw.tika.tests.utils import RaisingConverter
 from ftw.tika.transforms.tika_to_plain_text import Tika2TextTransform
-from testfixtures import log_capture
 from zope.interface.verify import verifyClass
 from zope.interface.verify import verifyObject
 
@@ -59,27 +57,3 @@ class TestTransforms(MockTestCase):
         transform = Tika2TextTransform()
         with self.assertRaises(KeyboardInterrupt):
             transform.convert('', stream)
-
-    @log_capture('ftw.tika')
-    def test_password_protected_PDF_document(self, log):
-        self.assertEquals(
-            '', convert_asset('protected.pdf'),
-            'Converting a password protected document should return an'
-            ' empty string, since we cannot extract anything.')
-
-        self.assertIn(
-            ('ftw.tika', 'INFO',
-             'Could not convert password protected document.'),
-            tuple(log.actual()))
-
-    @log_capture('ftw.tika')
-    def test_password_protected_WORD_document(self, log):
-        self.assertEquals(
-            '', convert_asset('protected.docx'),
-            'Converting a password protected document should return an'
-            ' empty string, since we cannot extract anything.')
-
-        self.assertIn(
-            ('ftw.tika', 'INFO',
-             'Could not convert password protected document.'),
-            tuple(log.actual()))

--- a/ftw/tika/transforms/tika_to_plain_text.py
+++ b/ftw/tika/transforms/tika_to_plain_text.py
@@ -1,8 +1,8 @@
-from Products.PortalTransforms.interfaces import ITransform
-from ZODB.POSException import ConflictError
-from ftw.tika import mimetypes
 from ftw.tika.converter import TikaConverter
 from ftw.tika.exceptions import TikaConversionError
+from ftw.tika.protected_docs import is_protected_doc
+from Products.PortalTransforms.interfaces import ITransform
+from ZODB.POSException import ConflictError
 from zope.interface import implements
 import logging
 
@@ -60,21 +60,11 @@ class Tika2TextTransform(object):
         return data
 
     def _log_conversion_error(self, exc, mimetype):
-        if ((mimetype in mimetypes.PDF_TYPES and
-             self._is_pdf_protected_exception(exc))
-            or (mimetype in mimetypes.MS_OFFICE_TYPES and
-                self._is_msoffice_protected_exception(exc))):
+        if is_protected_doc(exc, mimetype):
             logger.info('Could not convert password protected document.')
 
         else:
             logger.warn(exc)
-
-    def _is_pdf_protected_exception(self, exc):
-        return ('Error: The supplied password does not match either the'
-                ' owner or user password in the document.' in str(exc))
-
-    def _is_msoffice_protected_exception(self, exc):
-        return 'org.apache.tika.exception.EncryptedDocumentException' in str(exc)
 
 
 def register():

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '2.1.1.dev0'
+version = '2.2.0.dev0'
 
 tests_require = [
     'Products.CMFCore',

--- a/tika.cfg
+++ b/tika.cfg
@@ -19,15 +19,15 @@ zcml =
 
 [tika-app-download]
 recipe = hexagonit.recipe.download
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.6/tika-app-1.6.jar
-md5sum = 2d8af1f228000fcda92bd0dda20b80a8
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.7/tika-app-1.7.jar
+md5sum = a3deee3a02d59ad0085123806696f9f8
 download-only = true
 filename = tika-app.jar
 
 [tika-server-download]
 recipe = hexagonit.recipe.download
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.6/tika-server-1.6.jar
-md5sum = cdd68617e511010f76c357700ebad8c7
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.7/tika-server-1.7.jar
+md5sum = 97a9bd477747c65c7f89ccac3554f3ed
 download-only = true
 filename = tika-server.jar
 


### PR DESCRIPTION
Adds support for [Apache Tika 1.7](https://tika.apache.org/1.7/index.html).

With Tika >= 1.7, the exception message for password protected PDF files returned by PDFBox has changed. Therefore, the detection for password protected documents had to be extended. Other than that, this is just a version bump.