### PR TITLE
Add support for Tika 1.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,38 @@ This product integrates `Apache Tika <http://tika.apache.org/>`_ for full text
 indexing with **Plone** by providing portal transforms to ``text/plain`` for the
 various document formats supported by Tika.
 
+Compatibility
+-------------
+
+``ftw.tika`` is compatible with Plone 4.x and the Tika versions listed below
+(Plone and Tika versions can be mixed and matched).
+
++------------+--------------------+--+------------+---------------------+
+|  Tika 1.5  |  |Tika_15_Tests|_  |  |  Plone 4.1 |  |Plone_41_Tests|_  |
++------------+--------------------+--+------------+---------------------+
+|  Tika 1.6  |  |Tika_16_Tests|_  |  |  Plone 4.2 |  |Plone_42_Tests|_  |
++------------+--------------------+--+------------+---------------------+
+|  Tika 1.7  |  |Tika_17_Tests|_  |  |  Plone 4.3 |  |Plone_43_Tests|_  |
++------------+--------------------+--+------------+---------------------+
+
+.. |Tika_15_Tests| image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.5.cfg/badge/icon
+.. _Tika_15_Tests: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.5.cfg
+
+.. |Tika_16_Tests| image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.6.cfg/badge/icon
+.. _Tika_16_Tests: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.6.cfg
+
+.. |Tika_17_Tests| image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.7.cfg/badge/icon
+.. _Tika_17_Tests: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.7.cfg
+
+.. |Plone_41_Tests| image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.1.x.cfg/badge/icon
+.. _Plone_41_Tests: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.1.x.cfg
+
+.. |Plone_42_Tests| image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.2.x.cfg/badge/icon
+.. _Plone_42_Tests: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.2.x.cfg
+
+.. |Plone_43_Tests| image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.3.x.cfg/badge/icon
+.. _Plone_43_Tests: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.3.x.cfg
+
 
 Supported Formats
 =================
@@ -195,25 +227,6 @@ Uninstalling ftw.tika
 
 ``ftw.tika`` has an uninstall profile. To uninstall ``ftw.tika``, import the
 ``ftw.tika:uninstall`` profile using the ``portal_setup`` tool.
-
-
-Compatibility
--------------
-
-Plone 4.1
-
-.. image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.1.x.cfg/badge/icon
-   :target: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.1.x.cfg
-
-Plone 4.2
-
-.. image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.2.x.cfg/badge/icon
-   :target: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.2.x.cfg
-
-Plone 4.3
-
-.. image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.3.x.cfg/badge/icon
-   :target: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.3.x.cfg
 
 
 Configuration

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,8 @@ Compatibility
 +------------+--------------------+--+------------+---------------------+
 |  Tika 1.7  |  |Tika_17_Tests|_  |  |  Plone 4.3 |  |Plone_43_Tests|_  |
 +------------+--------------------+--+------------+---------------------+
+|  Tika 1.8  |  |Tika_18_Tests|_  |  |                                  |
++------------+--------------------+--+------------+---------------------+
 
 .. |Tika_15_Tests| image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.5.cfg/badge/icon
 .. _Tika_15_Tests: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.5.cfg
@@ -27,6 +29,9 @@ Compatibility
 
 .. |Tika_17_Tests| image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.7.cfg/badge/icon
 .. _Tika_17_Tests: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.7.cfg
+
+.. |Tika_18_Tests| image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.8.cfg/badge/icon
+.. _Tika_18_Tests: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-tika-1.8.cfg
 
 .. |Plone_41_Tests| image:: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.1.x.cfg/badge/icon
 .. _Plone_41_Tests: https://jenkins.4teamwork.ch/job/ftw.tika-master-test-plone-4.1.x.cfg
@@ -126,26 +131,34 @@ necessary, copy into your buildout and extend from:
 
     [tika-app-download]
     recipe = hexagonit.recipe.download
-    url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.7/tika-app-1.7.jar
-    md5sum = a3deee3a02d59ad0085123806696f9f8
+    url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.8/tika-app-1.8.jar
+    md5sum = 785aa2ba03a5ad205cb52765f69f66f3
     download-only = true
     filename = tika-app.jar
 
     [tika-server-download]
     recipe = hexagonit.recipe.download
-    url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.7/tika-server-1.7.jar
-    md5sum = 97a9bd477747c65c7f89ccac3554f3ed
+    url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.8/tika-server-1.8.jar
+    md5sum = 3ec6d893100e82ac25dc572e6eb1c9ad
     download-only = true
     filename = tika-server.jar
 
     [tika-server]
     recipe = collective.recipe.scriptgen
     cmd = java
-    arguments = -jar ${tika-server-download:destination}/${tika-server-download:filename} --port ${tika:server-port}
+    arguments = -jar ${tika-server-download:destination}/${tika-server-download:filename} --port ${tika:server-port} -includeStack
 
     [instance]
     zcml-additional = ${tika:zcml}
     eggs += ftw.tika
+
+
+.. note:: The ``-includeStack`` command line option for the Tika JAXRS server
+   is only available for Tika >= 1.8. If you're using an older version of Tika,
+   omit it from the arguments.
+   The option will make the Tika JAXRS server return Java stack traces in the
+   response body in case of conversion failures, and therefore allow
+   ``ftw.tika`` to provide more detailed error logging.
 
 
 If your deployment buildout is based on the deployment buildouts included
@@ -190,8 +203,8 @@ configuring ``ftw.tika`` with buildout:
 
     [tika-app]
     recipe = hexagonit.recipe.download
-    url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.6/tika-app-1.6.jar
-    md5sum = 2d8af1f228000fcda92bd0dda20b80a8
+    url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.8/tika-app-1.8.jar
+    md5sum = 785aa2ba03a5ad205cb52765f69f66f3
     download-only = true
     filename = tika-app.jar
 

--- a/README.rst
+++ b/README.rst
@@ -332,6 +332,18 @@ object. If no ``path`` keyword argument is supplied, the converter tries to
 get the path to the ``tika-app.jar`` from the ZCML configuration.
 
 
+Error logging
+-------------
+
+In order to get more detailed error logging when using the Tika JAXRS server,
+you can launch it with the ``-includeStack`` command line option and set the
+environment variable ``FTW_TIKA_VERBOSE_LOGGING`` to something truthy.
+
+``ftw.tika`` will then additionally log the output from Tika (which should
+contain the Java stack trace) in case of a conversion failure, giving you more
+information as to why the conversion failed.
+
+
 Links
 =====
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- Make use of the fact that Tika JAXRS server now can return the Java stack
+  traces in the response body, allowing ftw.tika to provide better error
+  logging in the case of conversion failures (for example, detecting that
+  conversion failed because a document is password protected).
+  [lgraf]
+
 - Add support for Tika 1.8
   [lgraf]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-2.2.1 (unreleased)
+2.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Tika 1.8
+  [lgraf]
 
 
 2.2.0 (2015-10-25)

--- a/ftw/tika/exceptions.py
+++ b/ftw/tika/exceptions.py
@@ -9,7 +9,19 @@ class ProcessError(Exception):
 
 class TikaConversionError(Exception):
     """Raised if an error happened during conversion with Tika.
+
+    May contain additional information about the error on the Tika side:
+    - status_code: The HTTP status code returned by the Tika JAXRS server
+    - stack_trace: The Java stack trace from the tika-app.jar, or, if
+      available, from the Tika JAXRS Server
     """
+    def __init__(self, message, status_code=None, stack_trace=None):
+        self.message = message
+        self.status_code = status_code
+        self.stack_trace = stack_trace
+
+    def __str__(self):
+        return self.message
 
 
 class TikaJarNotConfigured(Exception):

--- a/ftw/tika/protected_docs.py
+++ b/ftw/tika/protected_docs.py
@@ -24,10 +24,15 @@ def is_protected_doc(exc, mimetype):
     a password protected document, based on the document's MIME type and
     the Java exception.
     """
+    stack_trace = str(exc.stack_trace)
+    if not stack_trace:
+        # No Java stack trace to aid in the detection of the exact error
+        return False
+
     if mimetype in mimetypes.PDF_TYPES:
-        return any(msg in str(exc) for msg in PROTECTED_PDF_MSGS)
+        return any(msg in stack_trace for msg in PROTECTED_PDF_MSGS)
 
     if mimetype in mimetypes.MS_OFFICE_TYPES:
-        return any(msg in str(exc) for msg in PROTECTED_MSOFFICE_MSGS)
+        return any(msg in stack_trace for msg in PROTECTED_MSOFFICE_MSGS)
 
     return False

--- a/ftw/tika/testing.py
+++ b/ftw/tika/testing.py
@@ -14,6 +14,13 @@ import os
 import time
 
 
+def tika_version():
+    """Determine the Tika version we're testing against.
+    """
+    version = os.environ.get('TESTING_TIKA_VERSION', '0.0')
+    return tuple(map(int, version.split('.')))
+
+
 class MetaZCMLLayer(ComponentRegistryLayer):
 
     def setUp(self):

--- a/ftw/tika/testing.py
+++ b/ftw/tika/testing.py
@@ -1,9 +1,9 @@
 from ftw.testing import ComponentRegistryLayer
 from ftw.tika.interfaces import IZCMLTikaConfig
+from plone.app.testing import applyProfile
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from plone.app.testing import setRoles, TEST_USER_ID, TEST_USER_NAME, login
 from plone.testing import Layer
 from subprocess import Popen
@@ -99,7 +99,18 @@ class TikaServerLayer(Layer):
         srv_config = {'server_path': self['server_path']}
         srv_config.update(self['tika_config'])
 
-        command = 'java -jar %(server_path)s --port %(port)s' % (srv_config)
+        additional_opts = []
+
+        if tika_version() >= (1, 8):
+            # Tika 1.8 allows to include the Java stack traces in the
+            # response body for failed conversion requests.
+            additional_opts.append('-includeStack')
+
+        srv_config['additional_opts'] = ' '.join(additional_opts)
+
+        command = ('java -jar %(server_path)s --port %(port)s '
+                   '%(additional_opts)s' % (srv_config))
+
         self.process = Popen(command, shell=True)
         Thread(target=self.process.communicate).start()
         time.sleep(4.0)  # give tika some time to boot

--- a/ftw/tika/tests/test_integration.py
+++ b/ftw/tika/tests/test_integration.py
@@ -1,5 +1,6 @@
 from ftw.tika.testing import FTW_TIKA_INTEGRATION_TESTING
 from ftw.tika.testing import TIKA_SERVER_INTEGRATION_TESTING
+from ftw.tika.testing import tika_version
 from ftw.tika.tests.helpers import convert_asset
 from testfixtures import log_capture
 from unittest2 import TestCase
@@ -97,3 +98,27 @@ class TestServerConversion(TestCase):
 
     def test_eml_conversion(self):
         self.assertEquals('Lorem Ipsum', convert_asset('lorem.eml'))
+
+    @log_capture('ftw.tika')
+    def test_protected_pdf_conversion(self, log):
+        self.assertEquals('', convert_asset('protected.pdf'))
+        if tika_version() >= (1, 8):
+            self.assertIn(PROTECTED_MSG, tuple(log.actual()))
+        else:
+            # Assertion on status 422 doesn't work reliably - sometimes Tika
+            # fails with a 500, sometimes with 422 (for the same test)
+            self.assertIn(
+                'Conversion with Tika JAXRS server failed with status',
+                str(tuple(log.actual())))
+
+    @log_capture('ftw.tika')
+    def test_protected_docx_conversion(self, log):
+        self.assertEquals('', convert_asset('protected.docx'))
+        if tika_version() >= (1, 8):
+            self.assertIn(PROTECTED_MSG, tuple(log.actual()))
+        else:
+            # Assertion on status 422 doesn't work reliably - sometimes Tika
+            # fails with a 500, sometimes with 422 (for the same test)
+            self.assertIn(
+                'Conversion with Tika JAXRS server failed with status',
+                str(tuple(log.actual())))

--- a/ftw/tika/transforms/tika_to_plain_text.py
+++ b/ftw/tika/transforms/tika_to_plain_text.py
@@ -5,6 +5,7 @@ from Products.PortalTransforms.interfaces import ITransform
 from ZODB.POSException import ConflictError
 from zope.interface import implements
 import logging
+import os
 
 
 TIKA_TRANSFORM_NAME = 'tika_to_plain_text'
@@ -62,9 +63,11 @@ class Tika2TextTransform(object):
     def _log_conversion_error(self, exc, mimetype):
         if is_protected_doc(exc, mimetype):
             logger.info('Could not convert password protected document.')
-
         else:
             logger.warn(exc)
+            if os.environ.get('FTW_TIKA_VERBOSE_LOGGING', False):
+                msg = "Tika output:\n%s" % str(exc.stack_trace)
+                logger.warn(msg)
 
 
 def register():

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '2.2.1.dev0'
+version = '2.3.0.dev0'
 
 tests_require = [
     'Products.CMFCore',

--- a/test-tika-1.5.cfg
+++ b/test-tika-1.5.cfg
@@ -1,0 +1,18 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    tika.cfg
+
+package-name = ftw.tika
+
+[test]
+initialization +=
+    os.environ['TESTING_TIKA_VERSION'] = '1.5'
+
+[tika-app-download]
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
+md5sum = 2124a77289efbb30e7228c0f7da63373
+
+[tika-server-download]
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
+md5sum = 0f70548f233ead7c299bf7bc73bfec26

--- a/test-tika-1.6.cfg
+++ b/test-tika-1.6.cfg
@@ -1,0 +1,18 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    tika.cfg
+
+package-name = ftw.tika
+
+[test]
+initialization +=
+    os.environ['TESTING_TIKA_VERSION'] = '1.6'
+
+[tika-app-download]
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.6/tika-app-1.6.jar
+md5sum = 2d8af1f228000fcda92bd0dda20b80a8
+
+[tika-server-download]
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.6/tika-server-1.6.jar
+md5sum = cdd68617e511010f76c357700ebad8c7

--- a/test-tika-1.7.cfg
+++ b/test-tika-1.7.cfg
@@ -1,0 +1,18 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    tika.cfg
+
+package-name = ftw.tika
+
+[test]
+initialization +=
+    os.environ['TESTING_TIKA_VERSION'] = '1.7'
+
+[tika-app-download]
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.7/tika-app-1.7.jar
+md5sum = a3deee3a02d59ad0085123806696f9f8
+
+[tika-server-download]
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.7/tika-server-1.7.jar
+md5sum = 97a9bd477747c65c7f89ccac3554f3ed

--- a/test-tika-1.8.cfg
+++ b/test-tika-1.8.cfg
@@ -1,0 +1,18 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    tika.cfg
+
+package-name = ftw.tika
+
+[test]
+initialization +=
+    os.environ['TESTING_TIKA_VERSION'] = '1.8'
+
+[tika-app-download]
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.8/tika-app-1.8.jar
+md5sum = 785aa2ba03a5ad205cb52765f69f66f3
+
+[tika-server-download]
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.8/tika-server-1.8.jar
+md5sum = 3ec6d893100e82ac25dc572e6eb1c9ad

--- a/tika.cfg
+++ b/tika.cfg
@@ -19,22 +19,22 @@ zcml =
 
 [tika-app-download]
 recipe = hexagonit.recipe.download
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.7/tika-app-1.7.jar
-md5sum = a3deee3a02d59ad0085123806696f9f8
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.8/tika-app-1.8.jar
+md5sum = 785aa2ba03a5ad205cb52765f69f66f3
 download-only = true
 filename = tika-app.jar
 
 [tika-server-download]
 recipe = hexagonit.recipe.download
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.7/tika-server-1.7.jar
-md5sum = 97a9bd477747c65c7f89ccac3554f3ed
+url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.8/tika-server-1.8.jar
+md5sum = 3ec6d893100e82ac25dc572e6eb1c9ad
 download-only = true
 filename = tika-server.jar
 
 [tika-server]
 recipe = collective.recipe.scriptgen
 cmd = java
-arguments = -jar ${tika-server-download:destination}/${tika-server-download:filename} --port ${tika:server-port}
+arguments = -jar ${tika-server-download:destination}/${tika-server-download:filename} --port ${tika:server-port} -includeStack
 
 [instance]
 # Your plone.recipe.zope2instance part


### PR DESCRIPTION
This PR adds support for [Tika 1.8](https://tika.apache.org/1.8/index.html).

There have not been any *necessary* changes in the `ftw.tika` code to work with Tika 1.8, but there's a new feature we can take advantage of:

The Tika JAXRS Server in 1.8 now can return Java stack traces in the response body for failed conversions (if the `-includeStack` command line option was given). This allows us to do better error detection on the `ftw.tika` side, for example for detection conversion failures that happened because of passwort protected documents.

Therefore `ftw.tika` now tries to make use of any stack traces if present, but still will work just fine if the `-includeStack` flag is omitted (just with less detailed error logging).

If the environment variable ``FTW_TIKA_VERBOSE_LOGGING`` is set to something truthy, `ftw.tika` now also will log the Java stack trace (if available) upon conversion errors.

In addition, I extended the test setup so that `ftw.tika` is now tested against all supported versions of Tika.

@phgross @deiferni @jone 