### PR TITLE
Fall back to local Tika on any RequestException, not just Timeout.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- Fall back to local Tika on any RequestException, not just Timeout.
+  [lgraf]
+
 - Make use of the fact that Tika JAXRS server now can return the Java stack
   traces in the response body, allowing ftw.tika to provide better error
   logging in the case of conversion failures (for example, detecting that

--- a/ftw/tika/converter.py
+++ b/ftw/tika/converter.py
@@ -6,7 +6,7 @@ from ftw.tika.interfaces import IZCMLTikaConfig
 from ftw.tika.utils import clean_extracted_plaintext
 from ftw.tika.utils import run_process
 from plone.memoize import instance
-from requests.exceptions import Timeout
+from requests.exceptions import RequestException
 from StringIO import StringIO
 from zope.component import queryUtility
 import logging
@@ -92,7 +92,7 @@ class TikaConverter(object):
         if self.server_configured:
             try:
                 text = self.convert_server(document, filename)
-            except (socket.error, Timeout), exc:
+            except (socket.error, RequestException), exc:
                 self.log.error(
                     'Could not connect to tika server: %s' % str(exc))
                 # Use local tika as fallback


### PR DESCRIPTION
Fall back to local Tika on any [`RequestException`](https://github.com/kennethreitz/requests/blob/8f460faa31589a94311c179067debfe41f3e2f2e/requests/exceptions.py#L13), not just `Timeout`. This covers all sorts of network errors, like `ConnectionError` or `HTTPError`.

@deiferni @phgross 