### PR TITLE
make connection-timeout configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -231,6 +231,44 @@ configuring ``ftw.tika`` with buildout:
         </configure>
 
 
+Different Host buildout example
+-------------------------------
+
+If you already have a tika server (f.e. docker) you can connect to it without
+having to install it into the plone instance. Unfortunately if the system run
+into a timeout it will still try to use the local one as backup. (And produce
+an error in the log file)
+
+.. code:: ini
+
+    [buildout]
+
+    [tika]
+    server-port = 9998
+    server-host = myhost
+    server-timeout = 10
+    zcml =
+        <configure xmlns:tika="http://namespaces.plone.org/tika">
+            <tika:config host="${tika:server-host}"
+                         port="${tika:server-port}"
+                         timeout="${tika:server-timeout}" />
+        </configure>
+
+    [instance]
+    zcml-additional = ${tika:zcml}
+    eggs += ftw.tika
+
+
+You have the following configuration Options:
+
+* ``host``: the host where tika is running
+* ``port``: the port of the tika server
+* ``timeout``: you can define the connection timeout of the server in seconds
+
+``timeout`` defaults to 10 seconds and is configurable for your needs.
+0 means no timeout at all.
+
+
 Installing ftw.tika in Plone
 ----------------------------
 

--- a/ftw/tika/converter.py
+++ b/ftw/tika/converter.py
@@ -16,9 +16,6 @@ import socket
 import tempfile
 
 
-CONNECTION_TIMEOUT = 10.0
-
-
 def copy_stream(input_, output):
     """Reads from the ``input_`` stream or string and writes into
     the ``output``. It does this in a buffered fashion for making
@@ -112,8 +109,9 @@ class TikaConverter(object):
             document = StringIO(document)
 
         headers = {'Accept': 'text/plain'}
+        timeout = self.config.timeout
         response = requests.put(tika_endpoint, data=document, headers=headers,
-                                timeout=CONNECTION_TIMEOUT)
+                                timeout=timeout)
 
         status, body = response.status_code, response.content
 

--- a/ftw/tika/tests/test_meta_directive.py
+++ b/ftw/tika/tests/test_meta_directive.py
@@ -46,6 +46,22 @@ class TestTikaConfigDirective(TestCase):
         config = getUtility(IZCMLTikaConfig)
         self.assertEquals('localhost', config.host)
 
+    def test_config_stores_timeout(self):
+        self.load_zcml('<tika:config timeout="50" />')
+        config = getUtility(IZCMLTikaConfig)
+        self.assertEquals(50, config.timeout)
+
+    def test_config_defaults_timeout(self):
+        self.load_zcml('<tika:config />')
+        config = getUtility(IZCMLTikaConfig)
+        self.assertEquals(10, config.timeout)
+
+    def test_timeout_needs_to_be_integer(self):
+        with self.assertRaises(ConfigurationError) as cm:
+            self.load_zcml('<tika:config timeout="foo" />')
+        self.assertIn('ValueError: invalid literal for int',
+                      str(cm.exception))
+
     def load_zcml(self, *lines):
         self.layer.load_zcml_string('\n'.join((
                     '<configure xmlns:tika="http://namespaces.plone.org/tika">',

--- a/ftw/tika/zcml.py
+++ b/ftw/tika/zcml.py
@@ -8,10 +8,11 @@ from zope.interface import Interface
 class ZCMLTikaConfig(object):
     implements(IZCMLTikaConfig)
 
-    def __init__(self, path=None, port=None, host='localhost'):
+    def __init__(self, path=None, port=None, host='localhost', timeout=10):
         self.path = path
         self.port = port
         self.host = host
+        self.timeout = timeout
 
 
 class ITikaConfigDirective(Interface):
@@ -35,6 +36,12 @@ class ITikaConfigDirective(Interface):
         required=False,
         )
 
+    timeout = schema.Int(
+        title=u'Connection Timeout',
+        description=u'The timeout for the Connection to the tika server.',
+        required=False,
+        default=10)
+
 
 def tikaConfigDirective(_context, **arguments):
     """The <tika:config /> directive.
@@ -43,7 +50,8 @@ def tikaConfigDirective(_context, **arguments):
     <configure xmlns:tika="http://namespaces.plone.org/tika">
         <tika:config path="/path/to/tika-app.jar"
                      host="tika.host"
-                     port="9998" />
+                     port="9998"
+                     timeout="10" />
     </configure>
     """
 


### PR DESCRIPTION
This makes the connection-timeout configurable through the tika zcml configuration so the user can decide for themselves how long the timeout need to be.

In my case for example there where powerpoint files which needed to be indexed and they needed more time. Also i am using a docker setup where the tika server has it's own instance.