### PR TITLE
Use requests session.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.6.1 (unreleased)
 ------------------
 
+- Use requests session. [jone]
+
 - Make connection timeout configurable. [dready]
 
 


### PR DESCRIPTION
By using a thread-local requests session we can reuse the TCP connection, speeding up the conversion a little and reducing the "Starting new HTTP connection" messages in the log.

@lukasgraf can you take a short look at this one?