### PR TITLE
Remove local fallback when there was an error.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 2.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Remove local fallback when server fails. [jone]
 
 2.8.0 (2017-12-18)
 ------------------

--- a/ftw/tika/converter.py
+++ b/ftw/tika/converter.py
@@ -100,11 +100,19 @@ class TikaConverter(object):
         if self.server_configured:
             try:
                 text = self.convert_server(document, filename)
-            except (socket.error, RequestException), exc:
+
+            except requests.exceptions.ConnectionError, exc:
+                # Could not connect to the server at all.
+                # Server is probably not running
                 self.log.error(
                     'Could not connect to tika server: %s' % str(exc))
-                # Use local tika as fallback
                 text = self.convert_local(document, filename)
+
+            except (socket.error, RequestException), exc:
+                # An error occured, maybe a connection timeout.
+                self.log.error(
+                    'Full text extraction using tika failed: %s' % str(exc))
+                text = u''
         else:
             text = self.convert_local(document, filename)
 


### PR DESCRIPTION
When the tika server requires too much memory for extracting the text of a document, it could fail (maybe also because of a connection timeout). This did lead to a local fallback, causing an uncontrolled process to consume too much memory.

It is therefore better to not have automatic fallbacks.