### PR TITLE
Use https for downloading the java's jars.

### DIFF
--- a/test-tika-1.10.cfg
+++ b/test-tika-1.10.cfg
@@ -10,9 +10,9 @@ initialization +=
     os.environ['TESTING_TIKA_VERSION'] = '1.10'
 
 [tika-app-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.10/tika-app-1.10.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-app/1.10/tika-app-1.10.jar
 md5sum = a899be6467e446031315926c10b8763c
 
 [tika-server-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.10/tika-server-1.10.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.10/tika-server-1.10.jar
 md5sum = 973965a14c73a93315e756e62a18e8a0

--- a/test-tika-1.11.cfg
+++ b/test-tika-1.11.cfg
@@ -10,9 +10,9 @@ initialization +=
     os.environ['TESTING_TIKA_VERSION'] = '1.11'
 
 [tika-app-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.11/tika-app-1.11.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-app/1.11/tika-app-1.11.jar
 md5sum = c292fbb0b28fbe44f915229afb839db8
 
 [tika-server-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.11/tika-server-1.11.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.11/tika-server-1.11.jar
 md5sum = 3c8fb21140213a2f3fbac770358034ab

--- a/test-tika-1.5.cfg
+++ b/test-tika-1.5.cfg
@@ -10,9 +10,9 @@ initialization +=
     os.environ['TESTING_TIKA_VERSION'] = '1.5'
 
 [tika-app-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-app/1.5/tika-app-1.5.jar
 md5sum = 2124a77289efbb30e7228c0f7da63373
 
 [tika-server-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.5/tika-server-1.5.jar
 md5sum = 0f70548f233ead7c299bf7bc73bfec26

--- a/test-tika-1.6.cfg
+++ b/test-tika-1.6.cfg
@@ -10,9 +10,9 @@ initialization +=
     os.environ['TESTING_TIKA_VERSION'] = '1.6'
 
 [tika-app-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.6/tika-app-1.6.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-app/1.6/tika-app-1.6.jar
 md5sum = 2d8af1f228000fcda92bd0dda20b80a8
 
 [tika-server-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.6/tika-server-1.6.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.6/tika-server-1.6.jar
 md5sum = cdd68617e511010f76c357700ebad8c7

--- a/test-tika-1.7.cfg
+++ b/test-tika-1.7.cfg
@@ -10,9 +10,9 @@ initialization +=
     os.environ['TESTING_TIKA_VERSION'] = '1.7'
 
 [tika-app-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.7/tika-app-1.7.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-app/1.7/tika-app-1.7.jar
 md5sum = a3deee3a02d59ad0085123806696f9f8
 
 [tika-server-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.7/tika-server-1.7.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.7/tika-server-1.7.jar
 md5sum = 97a9bd477747c65c7f89ccac3554f3ed

--- a/test-tika-1.8.cfg
+++ b/test-tika-1.8.cfg
@@ -10,9 +10,9 @@ initialization +=
     os.environ['TESTING_TIKA_VERSION'] = '1.8'
 
 [tika-app-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.8/tika-app-1.8.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-app/1.8/tika-app-1.8.jar
 md5sum = 785aa2ba03a5ad205cb52765f69f66f3
 
 [tika-server-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.8/tika-server-1.8.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.8/tika-server-1.8.jar
 md5sum = 3ec6d893100e82ac25dc572e6eb1c9ad

--- a/test-tika-1.9.cfg
+++ b/test-tika-1.9.cfg
@@ -10,9 +10,9 @@ initialization +=
     os.environ['TESTING_TIKA_VERSION'] = '1.9'
 
 [tika-app-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.9/tika-app-1.9.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-app/1.9/tika-app-1.9.jar
 md5sum = 7b73ce50ac217021aa51dd3d1ef2ce13
 
 [tika-server-download]
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.9/tika-server-1.9.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.9/tika-server-1.9.jar
 md5sum = 4ec60fb9c7bc9341fd4feec74e39bc1e

--- a/tika.cfg
+++ b/tika.cfg
@@ -19,14 +19,14 @@ zcml =
 
 [tika-app-download]
 recipe = hexagonit.recipe.download
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-app/1.11/tika-app-1.11.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-app/1.11/tika-app-1.11.jar
 md5sum = c292fbb0b28fbe44f915229afb839db8
 download-only = true
 filename = tika-app.jar
 
 [tika-server-download]
 recipe = hexagonit.recipe.download
-url = http://repo1.maven.org/maven2/org/apache/tika/tika-server/1.11/tika-server-1.11.jar
+url = https://repo1.maven.org/maven2/org/apache/tika/tika-server/1.11/tika-server-1.11.jar
 md5sum = 3c8fb21140213a2f3fbac770358034ab
 download-only = true
 filename = tika-server.jar


### PR DESCRIPTION
The central maven repository no longer supports insecure communication over plain http and requires that all requests to the repository are encrypted over https.

See https://links.sonatype.com/central/501-https-required.