### PR TITLE
Drop flaky tests against deprecated plone 4.2.

### DIFF
--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    tika.cfg
-
-package-name = ftw.tika


### PR DESCRIPTION
As far as i've seen we no longer use plone 4.2 anywhere with ftw.tika.

And even if we do i don't really care about that old and deprecated version any more. I think in the year 2021 we can safely assume that at least plone 4.3 is in use for a productive deployment.