### PR TITLE
Fix tests: Pin testfixtures to last Py2.7 compatible version.

### DIFF
--- a/tika.cfg
+++ b/tika.cfg
@@ -44,3 +44,7 @@ eggs += ftw.tika
 [supervisor]
 programs +=
     20 tika-server (stopasgroup=true) ${buildout:bin-directory}/tika-server true zope
+
+[versions]
+# Last Python 2.7 compatible version
+testfixtures = 6.18.5


### PR DESCRIPTION
Pin `testfixtures` to last Py2.7 compatible version. Fixes

```
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/ftw.tika@3/ftw/tika/tests/test_integration.py", line 5, in <module>
    from testfixtures import log_capture
  File "/var/lib/jenkins/zope/eggs/testfixtures-7.0.0-py2.7.egg/testfixtures/__init__.py", line 12
    not_there: singleton = singleton('not_there')
             ^
SyntaxError: invalid syntax
```

and therefore test failures like these: https://ci.4teamwork.ch/builds/517327/tasks/986795